### PR TITLE
Fix ethers big number comparison

### DIFF
--- a/defender/auto-fund-chainlink-subscription/autotasks/detect-low-balance/index.js
+++ b/defender/auto-fund-chainlink-subscription/autotasks/detect-low-balance/index.js
@@ -9,13 +9,15 @@ export async function handler(event) {
   const thresholdInWei = ethers.utils.parseEther(threshold);
   const provider = new DefenderRelayProvider(event);
   const payload = event.request.body;
+  console.log(`Threshold is ${threshold} LINK`);
 
   const vrfCoordinator = new ethers.Contract(vrfCoordinatorAddress, ABI, provider);
   const { balance } = await vrfCoordinator.getSubscription(subscriptionId);
-  console.log(`Your balance is ${balance}`);
+  console.log(`Your subscription balance is ${ethers.utils.formatEther(balance)} LINK`);
 
   const matches = [];
-  if (balance < thresholdInWei) {
+  if (balance.lt(thresholdInWei)) {
+    console.log(`Balance is below threshold, emitting alert...`);
     const match = {
       hash: payload.events[0].transaction.transactionHash, //The actual hash is not important. We won't need it in the autotask notification
       metadata: {},


### PR DESCRIPTION
# Description
Fixes an issue in the autotask condition. When comparing to ethers big numbers you can get false positives and trigger an alert for no valid reason. Also added some additional logs for clarity.

> JavaScript uses [IEEE 754 double-precision binary floating point](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) numbers to represent numeric values. As a result, there are holes in the integer set after 9,007,199,254,740,991; which is problematic for Ethereum because that is only around 0.009 ether (in wei), which means any value over that will begin to experience rounding errors.

https://docs.ethers.org/v5/api/utils/bignumber/#:~:text=A%20BigNumber%20is%20an%20object,values%20will%20generally%20accept%20them.