### PR TITLE
upgrade serverless version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/yargs": "^17.0.19",
     "@typescript-eslint/parser": "^5.48.1",
     "chai": "^4.3.7",
-    "defender-serverless": "1.0.3",
+    "defender-serverless": "1.0.4",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-promise": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,38 @@
     d "1"
     es5-ext "^0.10.47"
 
+"@aws-crypto/sha256-js@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz#02acd1a1fda92896fc5a28ec7c6e164644ea32fc"
+  integrity sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==
+  dependencies:
+    "@aws-crypto/util" "^1.2.2"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-1.2.2.tgz#b28f7897730eb6538b21c18bd4de22d0ea09003c"
+  integrity sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==
+  dependencies:
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/types@^3.1.0":
+  version "3.272.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.272.0.tgz#83670e4009c2e72f1fdf55816c55c9f8b5935e0a"
+  integrity sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.259.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz#3275a6f5eb334f96ca76635b961d3c50259fd9ff"
+  integrity sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==
+  dependencies:
+    tslib "^2.3.1"
+
 "@babel/code-frame@^7.0.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1759,6 +1791,17 @@ amazon-cognito-identity-js@^4.3.3:
     isomorphic-unfetch "^3.0.0"
     js-cookie "^2.2.1"
 
+amazon-cognito-identity-js@^6.0.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.1.2.tgz#975df21b0590098c2d3f455f48dbba255560bbf5"
+  integrity sha512-Ptutf9SLvKEM1Kr2kTPUvu/9THjQ0Si1l80iZYcS8NqScAAiDg8WjOOhQeJPcQDXt3Vym91luZ6zNW/3ErjEdQ==
+  dependencies:
+    "@aws-crypto/sha256-js" "1.2.2"
+    buffer "4.9.2"
+    fast-base64-decode "^1.0.0"
+    isomorphic-unfetch "^3.0.0"
+    js-cookie "^2.2.1"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -3378,7 +3421,7 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-defender-admin-client@^1.29.0-rc.1, defender-admin-client@^1.31.1, defender-admin-client@^1.37.0:
+defender-admin-client@^1.29.0-rc.1, defender-admin-client@^1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/defender-admin-client/-/defender-admin-client-1.37.0.tgz#d4b6cc6c7ebaa9aab138f39b10572018c25dc9a1"
   integrity sha512-0I0n+LUo4X75uiy/Sd5V5Qv1HwhmIvC++uswxx8xnQ0VUK+y0ic0uMk/8ACrItH/9EGH2YrURNm8ZGg9AY1K5A==
@@ -3388,13 +3431,37 @@ defender-admin-client@^1.29.0-rc.1, defender-admin-client@^1.31.1, defender-admi
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
-defender-autotask-client@^1.31.1, defender-autotask-client@^1.37.0:
+defender-admin-client@^1.38.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-admin-client/-/defender-admin-client-1.39.0.tgz#6874af116ba69e640cef0ae6e5d74b17f2f1e307"
+  integrity sha512-z+HXz7WQmaE8vivusfmMXEehKBXLMsr0GalKKeCTQnod3UTz0JSbPIU4Sw2RPuQQPtCv4oRePGyOy429q64KAw==
+  dependencies:
+    axios "^0.21.2"
+    defender-base-client "1.39.0"
+    ethers "^5.7.2"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
+
+defender-autotask-client@^1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/defender-autotask-client/-/defender-autotask-client-1.37.0.tgz#3b59ac826e6d5df4fa3f706f36e09aad07e786d0"
   integrity sha512-N66buqg7mgYiEMbN6R+/6tUB4gxp5Q9cu8QDFuDkviR32AxZ2jY7LqV+GkR/9dbRufQtb4ZRf+ihG/b01w5O5Q==
   dependencies:
     axios "^0.21.2"
     defender-base-client "1.37.0"
+    dotenv "^10.0.0"
+    glob "^7.1.6"
+    jszip "^3.5.0"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
+
+defender-autotask-client@^1.38.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-autotask-client/-/defender-autotask-client-1.39.0.tgz#159135c82a9f6116835e1cdddff5671777fa60fa"
+  integrity sha512-mL8sMameNIPRlLCjPFbGxYV6+UPYzDHVwYo8QZk7KEazB70HPzTvpFZ+hKwK4H0SxTgJkyAjyiN0dWPWs2Zgyg==
+  dependencies:
+    axios "^0.21.2"
+    defender-base-client "1.39.0"
     dotenv "^10.0.0"
     glob "^7.1.6"
     jszip "^3.5.0"
@@ -3412,7 +3479,18 @@ defender-base-client@1.37.0, defender-base-client@^1.3.1:
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
-defender-relay-client@^1.31.1, defender-relay-client@^1.37.0:
+defender-base-client@1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-base-client/-/defender-base-client-1.39.0.tgz#c6768821527b608047de903ed682267bd86b50fd"
+  integrity sha512-x5GqEL2IHwnOLEqgzlyp0qa08hWCOGLn1idY8PucTrXo6ZMQGxQtPMx8LAquBvOD4rC3EPsr2qzln00isFcr/A==
+  dependencies:
+    amazon-cognito-identity-js "^6.0.1"
+    async-retry "^1.3.3"
+    axios "^0.21.2"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
+
+defender-relay-client@^1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/defender-relay-client/-/defender-relay-client-1.37.0.tgz#e6db1cccd8924b2e91e89635d88bf50099c28afc"
   integrity sha512-c2V1AxPmnRC8Gj62cI2WQFJR4GECPoktbiGf/+l37Wxrnh38f4My/o6nZ/tqGkGt4kt8kzfmqciI2lNiUtlPDA==
@@ -3423,7 +3501,18 @@ defender-relay-client@^1.31.1, defender-relay-client@^1.37.0:
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
-defender-sentinel-client@^1.31.1, defender-sentinel-client@^1.37.0:
+defender-relay-client@^1.38.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-relay-client/-/defender-relay-client-1.39.0.tgz#d9b2fb60fd34aa499fcce21564c1223f31736ba6"
+  integrity sha512-5jdE8gWtIwqOH8eQ6YpL52HrYERfn3Zn7FNfp3lZcrQn5tQi6/bnIjrFrALpWlnyEz/mo7C+r1L49blDrlxjiw==
+  dependencies:
+    amazon-cognito-identity-js "^6.0.1"
+    axios "^0.21.2"
+    defender-base-client "1.39.0"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
+
+defender-sentinel-client@^1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/defender-sentinel-client/-/defender-sentinel-client-1.37.0.tgz#d5ac68f76ce901e0c8773504ce69412057616a79"
   integrity sha512-7OuZXrbnEXgq2EWHRdNOmRdhuKsQRLPOGhFmWSHu5HPBwLYFMkDWnEMJuzU8yBdJ12e1mAkA5ikNPrtGO9VHmw==
@@ -3434,15 +3523,26 @@ defender-sentinel-client@^1.31.1, defender-sentinel-client@^1.37.0:
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
-defender-serverless@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/defender-serverless/-/defender-serverless-1.0.3.tgz#8ea88003a06d9248e92857d33fe6d1a224d9748f"
-  integrity sha512-P9Td0LIwyOjbpCerFggM2SiN6A9QCfiLvaSalbjIQr6o5sZRzbZvwWwHyLUoKYpdsY5bzqA7exO5hkF8CexqmA==
+defender-sentinel-client@^1.38.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-sentinel-client/-/defender-sentinel-client-1.39.0.tgz#98345b7c319f18452b4bda7cfe5f817bf3db1a53"
+  integrity sha512-PHQHGC+j7bjjjm8GTWNhVp8xsBrl7T98lBFQKKaihMRrtpcr5catoidG7mdu5MKpb6PMrIQ6Qsisf0YhDVCRUw==
   dependencies:
-    defender-admin-client "^1.31.1"
-    defender-autotask-client "^1.31.1"
-    defender-relay-client "^1.31.1"
-    defender-sentinel-client "^1.31.1"
+    "@ethersproject/abi" "^5.6.3"
+    axios "^0.21.2"
+    defender-base-client "1.39.0"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
+
+defender-serverless@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/defender-serverless/-/defender-serverless-1.0.4.tgz#a29357b7f0bdf7aafd307798ebb8443b1e54204f"
+  integrity sha512-hxXmLmLVwPidQ6Sn7klpItQRa4nyEEZZ3PmSGo1NXLx85blA8ZwHC7zi20MuKq4SfU8MLIbkFPDPyA6E5WROFw==
+  dependencies:
+    defender-admin-client "^1.38.0"
+    defender-autotask-client "^1.38.0"
+    defender-relay-client "^1.38.0"
+    defender-sentinel-client "^1.38.0"
     lodash "^4.17.21"
     prompt "^1.3.0"
 
@@ -9299,7 +9399,7 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -9308,6 +9408,11 @@ tslib@^2.1.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tslib@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsort@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
# Description
After our conversation with the Defender team today I tested some teamplates with `1.0.4 `version and everything is working smoothly. Sentinels, autotasks, notifications and relayers are being deployed correctly.
1.0.4 adds support for zkSync testnet, so it's something that we want to have for ETH Denver.